### PR TITLE
FOGL-2162: evaluate conditions for sending notifications

### DIFF
--- a/include/notification_manager.h
+++ b/include/notification_manager.h
@@ -15,6 +15,11 @@
 #include <rule_plugin.h>
 #include <delivery_plugin.h>
 
+// Notification type repeat frequency
+#define DEFAULT_RETRIGGER_FREQUENCY 60
+#define DEFAULT_ONESHOT_FREQUENCY   60
+#define DEFAULT_TOGGLE_FREQUENCY    60
+
 /**
  * The EvaluationType class represents
  * the evalutation type of notification data.
@@ -156,6 +161,7 @@ class NotificationInstance
 {
 	public:
 		enum NotificationType { None, OneShot, Retriggered, Toggled };
+		enum NotificationState {StateTriggered, StateCleared };
 		NotificationInstance(const std::string& name,
 				     bool enable,
 				     NotificationType type,
@@ -179,6 +185,7 @@ class NotificationInstance
 		bool			isEnabled() const { return m_enable; };
 		NotificationType	getType() const { return m_type; };
 		string			getTypeString(NotificationType type);
+		bool			handleState(bool evalRet);
 
 	private:
 		const std::string	m_name;
@@ -186,6 +193,8 @@ class NotificationInstance
 		NotificationType	m_type;
 		NotificationRule*	m_rule;
 		NotificationDelivery*	m_delivery;
+		time_t			m_lastSent;
+		NotificationState	m_state;
 };
 
 typedef NotificationInstance::NotificationType NOTIFICATION_TYPE;

--- a/notification_manager.cpp
+++ b/notification_manager.cpp
@@ -144,7 +144,7 @@ NotificationInstance::NotificationInstance(const string& name,
 					   m_rule(rule),
 					   m_delivery(delivery)
 {
-	// Set initila state fo notification delivery
+	// Set initial state fo notification delivery
 	m_lastSent = 0;
 	m_state = NotificationInstance::StateCleared;
 }
@@ -681,7 +681,7 @@ bool NotificationInstance::handleState(bool evalRet)
 {	
 	bool ret = false;
 	time_t now = time(NULL);
-        NotificationInstance::NotificationType type = this->getType();
+	NotificationInstance::NotificationType type = this->getType();
 
 	switch(type)
 	{


### PR DESCRIPTION
FOGL-2162: evaluate conditions for sending notifications

Addition of handleState() routine.

Its usage will be added to NotificationQueue::processAllDataBuffers with next commits