### PR TITLE
FOGL-2400: Clean current triggers when reconfiguring a notification rule

### DIFF
--- a/C/services/common/include/builtin_rule.h
+++ b/C/services/common/include/builtin_rule.h
@@ -80,12 +80,7 @@ class BuiltinRule
 		~BuiltinRule()
 		{
 			// Delete all triggers
-			for (auto r = m_triggers.begin();
-				  r != m_triggers.end();
-				  ++r)
-			{
-				delete (*r).second;
-			}
+			removeTriggers();
 		};
 
 		void		addTrigger(const std::string& asset,
@@ -94,6 +89,18 @@ class BuiltinRule
 			m_triggers.insert(std::pair<std::string,
 					  RuleTrigger *>(asset, trigger));
 		};
+		void		removeTriggers()
+				{
+					// Delete all triggers
+					for (auto r = m_triggers.begin();
+						  r != m_triggers.end();
+						  ++r)
+					{
+						delete (*r).second;
+					}
+
+					m_triggers.clear();
+				};
 
 		bool		hasTriggers() const { return m_triggers.size() != 0; };
 		std::map<std::string, RuleTrigger *>&

--- a/C/services/common/overmax_rule.cpp
+++ b/C/services/common/overmax_rule.cpp
@@ -417,6 +417,10 @@ void OverMaxRule::configure(const ConfigCategory& config)
 			// Configuration change is protected by a lock
 			lock_guard<mutex> guard(m_configMutex);
 
+			if (handle->hasTriggers())
+			{
+				handle->removeTriggers();
+			}
 			handle->addTrigger(assetName, pTrigger);
 		}
 		else


### PR DESCRIPTION
FOGL-2400: Clean current triggers when reconfiguring a notification rule