### PR TITLE
FOGL-2682: Adding new notification rule fails to deliver notification…

### DIFF
--- a/C/services/common/notification_manager.cpp
+++ b/C/services/common/notification_manager.cpp
@@ -921,7 +921,10 @@ RulePlugin* NotificationManager::createRuleCategory(const string& name,
 					    rulePluginConfig);
 
 	// Unregister configuration changes	
-	m_managerClient->unregisterCategory(ruleCategoryName);
+	// NOTE:
+	// currently unregisterCategory is not called
+	// as we don't change at run time the rule plugin
+	//m_managerClient->unregisterCategory(ruleCategoryName);
 
 	// Create category, don't merge existing values
 	if (!m_managerClient->addCategory(ruleDefConfig, false))
@@ -993,8 +996,11 @@ DeliveryPlugin* NotificationManager::createDeliveryCategory(const string& name,
 	DefaultConfigCategory deliveryDefConfig(deliveryCategoryName,
 						deliveryPluginConfig);
 
-	// Unregister configuration changes	
-	m_managerClient->unregisterCategory(deliveryCategoryName);
+	// Unregister configuration changes
+	// NOTE:
+	// currently unregisterCategory is not called
+	// as we don't change at run time the delivery plugin
+	//m_managerClient->unregisterCategory(deliveryCategoryName);
 
 	// Create category, don't merge existing values
 	if (!m_managerClient->addCategory(deliveryDefConfig, false))


### PR DESCRIPTION
…s until restart

FOGL-2682: Adding new notification rule fails to deliver notifications until restart

Note:
following statements removed as we don't change at runtime the rule/delivery plugins

m_managerClient->unregisterCategory(ruleCategoryName);
m_managerClient->unregisterCategory(deliveryCategoryName);