### PR TITLE
FOGL-2689 Implement Zombie state for deferred deletion

### DIFF
--- a/C/services/common/include/notification_manager.h
+++ b/C/services/common/include/notification_manager.h
@@ -197,6 +197,8 @@ class NotificationInstance
 		void			enable() { m_enable = true; };
 		void			disable() { m_enable = false; };
 		void			setType(NotificationType type) { m_type = type; }; 
+		void			markAsZombie() { m_zombie = true; };
+		bool			isZombie() { return m_zombie; };
 
 	private:
 		const std::string	m_name;
@@ -206,6 +208,7 @@ class NotificationInstance
 		NotificationDelivery*	m_delivery;
 		time_t			m_lastSent;
 		NotificationState	m_state;
+		bool			m_zombie;
 };
 
 typedef NotificationInstance::NotificationType NOTIFICATION_TYPE;
@@ -252,6 +255,7 @@ class NotificationManager
 		bool			auditNotification(const std::string& notification);
 		bool			APIdeleteInstance(const string& instanceName);
 		void			updateSentStats() { m_stats.sent++; };
+		void			collectZombies();
 
 	private:
 		PLUGIN_HANDLE		loadRulePlugin(const std::string& rulePluginName);

--- a/C/services/common/notification_queue.cpp
+++ b/C/services/common/notification_queue.cpp
@@ -342,6 +342,13 @@ bool NotificationQueue::feedAllDataBuffers(NotificationQueueElement* data)
 		}
 	}
 
+	/*
+	 * Now collect all pending deletes of notification instances
+	 * and really delete them. We defer this until we know we are not
+	 * processing any of the noptifications.
+	 */
+	NotificationManager::getInstance()->collectZombies();
+
 	return ret;
 }
 


### PR DESCRIPTION
Prevent deleting instances that are currently being processed by adding a mechanism to deferred the deletion until the processing has completed.