### PR TITLE
FOGL-2720: Change logic for "latest" evaluation type in notification …

### DIFF
--- a/C/services/common/include/notification_queue.h
+++ b/C/services/common/include/notification_queue.h
@@ -125,12 +125,12 @@ class NotificationQueue
 		void			setSumValues(std::map<std::string, ResultData>& result,
 						    const std::string& key,
 						    DatapointValue& val);
-		void			deliverNotification(NotificationRule* rule,
-							    const std::string& data);
 		void			aggregateData(std::vector<NotificationDataElement *>& readingsData,
 						      unsigned long size,
 						      EvaluationType::EVAL_TYPE type,
-						       std::map<std::string, std::string>& result);
+						      std::map<std::string, std::string>& result);
+		void			setLatestData(vector<NotificationDataElement *>& readingsData,
+						      map<string, AssetData>& results);
 
 	private:
 		/**
@@ -185,18 +185,19 @@ class NotificationQueue
 class ResultData
 {
 	public:
-		std::vector<Datapoint*>
-				vData;
+		std::vector<Datapoint*> vData;
 };
 
 /**
  * This class keeps the string results of an evaluated asset and its datapoints
+ * and a vector or Reading data for Latest evaluation type
  */
 class AssetData
 {
 	public:
 		EvaluationType::EVAL_TYPE
-				type;
-		std::string     sData;
+					type;
+		std::string     	sData;
+		std::vector<Reading*>	rData;
 };
 #endif


### PR DESCRIPTION
FOGL-2720: Change logic for "latest" evaluation type in notification server


if Latest is set for notification evaluation_type, then each reading data in the buffers is evaluated.

Notes

If a notification rule plugin registers for two assets and one requires Average and the other Latest
the rule evaluation routine is called with each reading data for Latest and the calculated value of Average

Example, assuming Average window is set to 30 seconds:

after that time we have the calculated value of Average and, say, 100 readings of the other asset (Latest)

Asset flow (latest)
Asset current (Average)

1 eval  { "flow" : { "point_X" : 85 }, "current" : { "device_A" : 0.994 } }
2 eval  { "flow" : { "point_X" : 78 }, "current" : { "device_A" : 0.994 } }
...
100 eval  { "flow" : { "point_X" : 98 }, "current" : { "device_A" : 0.994 } }


In case of more than one asset with Latest a timeline object is created
containing a global Latest data ordered by timestamps (in microseconds)

Example with two assets, evaluation type is Latest for both:

1 eval { "current" : { "device_A" : 0.58 } }
2 eval { "flow" : { "point_X" : 91 }, "current" : { "device_A" : 0.58 } }
3 eval { "flow" : { "point_X" : 45 }, "current" : { "device_A" : 0.58 } }


Time t1 only current is passed to eval
Time t2 both assets are passed to eval with new values
Time t3 both assets are passed to eval, only 'flow' has a new value, 'current' holds previous one
