### PR TITLE
FOGL-2860: Fix datapoints list in Latest notification JSON sent to plugin_eval

### DIFF
--- a/C/services/common/notification_queue.cpp
+++ b/C/services/common/notification_queue.cpp
@@ -1470,7 +1470,7 @@ static void deliverData(NotificationRule* rule,
 		{
 			// AssetName
 			string assetName = (*eq).second->getAssetName();
-			string assetValue = "\"" + assetName + "\" : { \"";
+			string assetValue = "\"" + assetName + "\" : { ";
 
 			// DataPoints
 			std::vector<Datapoint *>& data = (*eq).second->getReadingData();
@@ -1479,7 +1479,7 @@ static void deliverData(NotificationRule* rule,
 				  ++d)
 			{
 				// Datapoint name and val
-				assetValue += (*d)->getName()  + "\" : " + (*d)->getData().toString();
+				assetValue += "\"" + (*d)->getName()  + "\" : " + (*d)->getData().toString();
 				if (next(d, 1) != data.end())
 				{
 					assetValue += ", " ;


### PR DESCRIPTION
FOGL-2860: Fix datapoints list in Latest notification JSON sent to plugin_eval

Wrong JSON, miissing double quotes around datapoint names

{ "sinusoid" : { "y" : -5.978147601, x" : 10.994521895, sinusoid" : -1.0 } }