### PR TITLE
FOGL-3297: use urlEncode/Decode in asset name notifications

### DIFF
--- a/C/services/common/include/notification_api.h
+++ b/C/services/common/include/notification_api.h
@@ -20,7 +20,7 @@ using HttpServer = SimpleWeb::Server<SimpleWeb::HTTP>;
  * URL for each API entry point
  */
 #define ESCAPE_SPECIAL_CHARS		"\\{\\}\\\"\\(\\)\\!\\[\\]\\^\\$\\.\\|\\?\\*\\+\\-"
-#define RECEIVE_NOTIFICATION		"^/notification/reading/asset/([A-Za-z][a-zA-Z0-9_\\-]*)$"
+#define RECEIVE_NOTIFICATION		"^/notification/reading/asset/([A-Za-z][a-zA-Z0-9_%\\-]*)$"
 #define GET_NOTIFICATION_INSTANCES	"^/notification$"
 #define GET_NOTIFICATION_DELIVERY	"^/notification/delivery$"
 #define GET_NOTIFICATION_RULES		"^/notification/rules$"

--- a/C/services/common/notification_subscription.cpp
+++ b/C/services/common/notification_subscription.cpp
@@ -16,6 +16,7 @@
 #include <logger.h>
 #include <iostream>
 #include <string>
+#include <string_utils.h>
 #include <notification_subscription.h>
 #include <notification_api.h>
 #include <notification_queue.h>
@@ -92,7 +93,7 @@ void NotificationSubscription::unregisterSubscriptions()
 	{
 		// Unregister interest
 		m_storage.unregisterAssetNotification((*it).first,
-						      callBackURL + (*it).first);
+						      callBackURL + urlEncode((*it).first));
 		m_logger->info("Unregistering asset '" + \
 			       (*it).first + "' for notification " + \
 			       this->getNotificationName());
@@ -180,7 +181,7 @@ bool NotificationSubscription::addSubscription(const std::string& assetName,
 	if (m_subscriptions[assetName].size() == 1)
 	{
 		m_storage.registerAssetNotification(assetName,
-						    (callBackURL + assetName));
+						    (callBackURL + urlEncode(assetName)));
 
 		m_logger->info("Registering asset '" + \
 			       assetName + "' for notification " + \
@@ -251,7 +252,7 @@ void NotificationSubscription::unregisterSubscription(const string& assetName)
 	{
 		// Unregister interest
 		m_storage.unregisterAssetNotification((*it).first,
-						      callBackURL + assetName);
+						      callBackURL + urlEncode(assetName));
 
 		m_logger->info("Unregistering asset '" + \
 				assetName + "' for notification " + \


### PR DESCRIPTION
FOGL-3297: use urlEncode/Decode in asset name notifications


FogLAMP branch FOGL-3297, merged to develop